### PR TITLE
January post CPU update to test code

### DIFF
--- a/ContainerFile
+++ b/ContainerFile
@@ -1,0 +1,18 @@
+# File for creating a container of this testsuite.
+FROM registry.access.redhat.com/ubi8/openjdk-8:latest
+USER root
+RUN whoami
+
+# Install required utilities
+RUN microdnf -y install util-linux
+
+# Create the directory structure for the testing.
+RUN mkdir -p /tmp/rhscl_openshift_dir/openjdk
+WORKDIR /tmp/rhscl_openshift_dir/openjdk
+COPY . .
+
+# Update the permissions on the testsuite
+RUN chgrp -R 0 /tmp/rhscl_openshift_dir/openjdk && \
+    chmod -R g=u /tmp/rhscl_openshift_dir/openjdk && \
+    chgrp -R 0 /home && \
+    chmod -R g=u /home

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This test suite is designed to be executed against current versions of Red Hat's
 | UBI 8                    | 8               | [openjdk-8](https://catalog.redhat.com/software/containers/ubi8/openjdk-8/5dd6a48dbed8bd164a09589a)                                  |
 | UBI 8                    | 11              | [openjdk-11](https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4)                                |
 | UBI 8                    | 17              | [openjdk-17](https://catalog.redhat.com/software/containers/ubi8/openjdk-17/618bdbf34ae3739687568813)                                |
-| UBI 8                    | 21              | TBD                                                                                                                                  | 
+| UBI 8                    | 21              | [openjdk-21](https://catalog.redhat.com/software/containers/ubi8/openjdk-21/653fb7e21b2ec10f7dfc10d0)                                | 
 | UBI 9                    | 11              | [openjdk-11](https://catalog.redhat.com/software/containers/ubi9/openjdk-11/61ee7bafed74b2ffb22b07ab)                                |
 | UBI 9                    | 17              | [openjdk-17](https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6)                                |
-| UBI 9                    | 21              | TBD                                                                                                                                  |
+| UBI 9                    | 21              | [openjdk-21](https://catalog.redhat.com/software/containers/ubi9/openjdk-21/6501cdb5c34ae048c44f7814)                                                                                                                       |
 **Note**: `OpenJDK runtime images are not currently supported by this test suite.` 
 
 ***

--- a/global-test.properties
+++ b/global-test.properties
@@ -3,19 +3,19 @@
 #############################################
 
 # UBI 8 (Rhel 8) version of the container
-xtf.openjdk.8.image=registry.access.redhat.com/ubi8/openjdk-8:1.18-2
+xtf.openjdk.8.image=registry.access.redhat.com/ubi8/openjdk-8:1.18-2.1705572794
 xtf.openjdk.8.version=1.8.0
 
 # UBI 8 (Rhel 8) version of the container
-xtf.openjdk.11.image=registry.access.redhat.com/ubi8/openjdk-11:1.18-2
+xtf.openjdk.11.image=registry.access.redhat.com/ubi8/openjdk-11:1.18-2.1705602259
 xtf.openjdk.11.version=11
 
 #JDK 17 image reference
-xtf.openjdk.17.image=registry.access.redhat.com/ubi8/openjdk-17:1.18-2
+xtf.openjdk.17.image=registry.access.redhat.com/ubi8/openjdk-17:1.18-2.1705573234
 xtf.openjdk.17.version=17
 
 #JDK 21 image reference
-xtf.openjdk.21.image=registry.access.redhat.com/ubi8/openjdk-21:1.18-3
+xtf.openjdk.21.image=registry.access.redhat.com/ubi8/openjdk-21:1.18-3.1705519633
 xtf.openjdk.21.version=21
 
 #############################################


### PR DESCRIPTION
This is the post CPU update to the test code. Included in the update, updated versions of the container tags, updated the readme to include a link to the OpenJDK 21 images and readded the containerfile to support the InterOp testing.