### PR TITLE
[OPENJDK-2425]Revert label check condition. Update build numbers for …

### DIFF
--- a/global-test.properties
+++ b/global-test.properties
@@ -3,19 +3,19 @@
 #############################################
 
 # UBI 8 (Rhel 8) version of the container
-xtf.openjdk.8.image=registry.access.redhat.com/ubi8/openjdk-8:1.18-2.1705572794
+xtf.openjdk.8.image=registry.access.redhat.com/ubi8/openjdk-8:1.19-1
 xtf.openjdk.8.version=1.8.0
 
 # UBI 8 (Rhel 8) version of the container
-xtf.openjdk.11.image=registry.access.redhat.com/ubi8/openjdk-11:1.18-2.1705602259
+xtf.openjdk.11.image=registry.access.redhat.com/ubi8/openjdk-11:1.19-1
 xtf.openjdk.11.version=11
 
 #JDK 17 image reference
-xtf.openjdk.17.image=registry.access.redhat.com/ubi8/openjdk-17:1.18-2.1705573234
+xtf.openjdk.17.image=registry.access.redhat.com/ubi8/openjdk-17:1.19-1
 xtf.openjdk.17.version=17
 
 #JDK 21 image reference
-xtf.openjdk.21.image=registry.access.redhat.com/ubi8/openjdk-21:1.18-3.1705519633
+xtf.openjdk.21.image=registry.access.redhat.com/ubi8/openjdk-21:1.19-1
 xtf.openjdk.21.version=21
 
 #############################################

--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
@@ -131,8 +131,6 @@ public class DockerImageTest extends AbstractDockerImageTest {
 			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://jboss-container-images.github.io/openjdk/");
 		} else if (OpenJDKTestConfig.isOpenJDK17()){
 			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://jboss-container-images.github.io/openjdk/");
-		} else if (OpenJDKTestConfig.isRHEL9() && OpenJDKTestConfig.isOpenJDK21()){  //Temp fix until https://issues.redhat.com/browse/OPENJDK-2595
-			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/");
 		} else if (OpenJDKTestConfig.isOpenJDK21()){
 			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://jboss-container-images.github.io/openjdk/");
 		}


### PR DESCRIPTION
This is reverting the test change needed for the Jan cpu for the ubi9 jdk21 container. The label has been fixed. 