### PR TITLE
Fix JDK11 issue with IBM ppc64le or s390x

### DIFF
--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/OpenJDKTestConfig.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/OpenJDKTestConfig.java
@@ -76,10 +76,6 @@ public class OpenJDKTestConfig {
 		return getImageUrl().contains("ubi9");
 	}
 
-    public static boolean isOpenJ9() {
-        return image().getRepo().contains("openj9-");
-    }
-
 	public static boolean isMavenProxyEnabled() {
 		return mavenProxyUrl() != null;
 	}

--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/AbstractDockerImageTest.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/AbstractDockerImageTest.java
@@ -49,6 +49,15 @@ public abstract class AbstractDockerImageTest extends OpenJDKTestParent {
 			"jstat", "jstatd", "keytool", "pack200", "rmic",
 			"rmid", "rmiregistry", "serialver", "unpack200"
 	};
+	public static final String[] DEFAULT_IBM_P_Z_JAVA_11_UTILITIES = new String[]{
+		"alt-java", "jar", "jarsigner", "java",
+		"javac", "javadoc", "javap", "jcmd", "jconsole",
+		"jdb", "jdeprscan", "jdeps", "jfr", "jhsdb",
+		"jimage", "jinfo", "jjs", "jlink", "jmap",
+		"jmod", "jps", "jrunscript", "jshell", "jstack",
+		"jstat", "jstatd", "keytool", "pack200", "rmic",
+		"rmid", "rmiregistry", "serialver", "unpack200"
+  };
 	public static final String[] DEFAULT_JAVA_17_UTILITIES = new String[]{
 			"alt-java", "jar", "jarsigner", "java", "javac",
 			"javadoc", "javap", "jcmd", "jconsole", "jdb",

--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/AbstractDockerImageTest.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/AbstractDockerImageTest.java
@@ -49,15 +49,6 @@ public abstract class AbstractDockerImageTest extends OpenJDKTestParent {
 			"jstat", "jstatd", "keytool", "pack200", "rmic",
 			"rmid", "rmiregistry", "serialver", "unpack200"
 	};
-	public static final String[] DEFAULT_IBM_P_Z_JAVA_11_UTILITIES = new String[]{
-		"alt-java", "jar", "jarsigner", "java",
-		"javac", "javadoc", "javap", "jcmd", "jconsole",
-		"jdb", "jdeprscan", "jdeps", "jfr", "jhsdb",
-		"jimage", "jinfo", "jjs", "jlink", "jmap",
-		"jmod", "jps", "jrunscript", "jshell", "jstack",
-		"jstat", "jstatd", "keytool", "pack200", "rmic",
-		"rmid", "rmiregistry", "serialver", "unpack200"
-  };
 	public static final String[] DEFAULT_JAVA_17_UTILITIES = new String[]{
 			"alt-java", "jar", "jarsigner", "java", "javac",
 			"javadoc", "javap", "jcmd", "jconsole", "jdb",

--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
@@ -166,7 +166,7 @@ public class DockerImageTest extends AbstractDockerImageTest {
 			Assertions.assertThat(content.listDirContent("$JAVA_HOME/bin")).contains(super.DEFAULT_JAVA_8_UTILITIES);
 		// JDK 11 for Rhel 7, UBI 8, UBI 9
 		} else if (OpenJDKTestConfig.isOpenJDK11()){
-			// Is JDK 11 for IBM ppc64le & s390x
+			// Is JDK 11 for IBM ppc64le or s390x
 			if (isIBMArch) {
 				// Filter out "jaotc" from the default Java 11 utilities
 				List<String> filteredIBMJDK11Utilities = Arrays.stream(DEFAULT_JAVA_11_UTILITIES)

--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
@@ -155,15 +155,21 @@ public class DockerImageTest extends AbstractDockerImageTest {
 	@Override
 	@Test
 	public void javaUtilitiesTest() {
+		// Lets see if it is a IBM ppc64le or s390x JDK
+		boolean isPorZ = (metadata.labels().get("architecture").equals("ppc64le")) || (metadata.labels().get("architecture").equals("s390x"));
         //Content should match what is in the java/bin folder. Or the $JAVA_HOME/bin folder
 		// JDK 8 for UBI 8 and Rhel 7
 		if ( OpenJDKTestConfig.isOpenJDK8() || OpenJDKTestConfig.isOpenJDK8Rhel7() ) {
 			LOGGER.info("DockerImageTest:javaUtilitiesTest::Running check for jdk8.");
 			Assertions.assertThat(content.listDirContent("$JAVA_HOME/bin")).contains(super.DEFAULT_JAVA_8_UTILITIES);
 		// JDK 11 for Rhel 7, UBI 8, UBI 9
-		} else if (OpenJDKTestConfig.isOpenJDK11()){
+		} else if (OpenJDKTestConfig.isOpenJDK11() && !(isPorZ)){
 			LOGGER.info("DockerImageTest:javaUtilitiesTest::Running check for jdk11.");
 			Assertions.assertThat(content.listDirContent("$JAVA_HOME/bin")).contains(super.DEFAULT_JAVA_11_UTILITIES);
+		// JDK 11 for Rhel 7, UBI 8, UBI 9 on IBM ppc64le & s390x
+		} else if (OpenJDKTestConfig.isOpenJDK11() && (isPorZ)){
+			LOGGER.info("DockerImageTest:javaUtilitiesTest::Running check for jdk11 on ppc64le or s390x.");
+			Assertions.assertThat(content.listDirContent("$JAVA_HOME/bin")).contains(super.DEFAULT_IBM_P_Z_JAVA_11_UTILITIES);
 		// JDK 17 for UBI 8 and UBI 9
 		} else if (OpenJDKTestConfig.isOpenJDK17()){
 			LOGGER.info("DockerImageTest:javaUtilitiesTest::Running check for jdk17");
@@ -204,7 +210,6 @@ public class DockerImageTest extends AbstractDockerImageTest {
 		} else {
 			result.put("JAVA_HOME", OpenJDKTestConfig.isOpenJDK11() ? "/usr/lib/jvm/java-11" : "/usr/lib/jvm/java-1.8.0");
 		}
-		result.put("JAVA_VENDOR", OpenJDKTestConfig.isOpenJ9() ? "AdoptOpenJDK" : "openjdk");
 
 		if (OpenJDKTestConfig.isOpenJDK21()) {
 			result.put("JAVA_VERSION", "21");

--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
@@ -16,7 +16,6 @@ import com.redhat.qe.openjdk.OpenJDKTestConfig;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.regex.Pattern;
@@ -159,25 +158,22 @@ public class DockerImageTest extends AbstractDockerImageTest {
 	public void javaUtilitiesTest() {
 		// Lets see if it is a IBM ppc64le or s390x JDK
 		boolean isIBMArch = (metadata.labels().get("architecture").equals("ppc64le")) || (metadata.labels().get("architecture").equals("s390x"));
-        //Content should match what is in the java/bin folder. Or the $JAVA_HOME/bin folder
+		//Content should match what is in the java/bin folder. Or the $JAVA_HOME/bin folder
 		// JDK 8 for UBI 8 and Rhel 7
 		if ( OpenJDKTestConfig.isOpenJDK8() || OpenJDKTestConfig.isOpenJDK8Rhel7() ) {
 			LOGGER.info("DockerImageTest:javaUtilitiesTest::Running check for jdk8.");
 			Assertions.assertThat(content.listDirContent("$JAVA_HOME/bin")).contains(super.DEFAULT_JAVA_8_UTILITIES);
 		// JDK 11 for Rhel 7, UBI 8, UBI 9
 		} else if (OpenJDKTestConfig.isOpenJDK11()){
-			// Is JDK 11 for IBM ppc64le or s390x
+			// Is the JDK 11 for IBM ppc64le or s390x
 			if (isIBMArch) {
-				// Filter out "jaotc" from the default Java 11 utilities
-				List<String> filteredIBMJDK11Utilities = Arrays.stream(DEFAULT_JAVA_11_UTILITIES)
-        .filter(utility -> !"jaotc".equals(utility))
-        .collect(Collectors.toList());
+				// Filter out "jaotc" from the default Java 11 utilities and convert the result to an array
+				String [] updatedIBMJDK11Utilities = Arrays.stream(DEFAULT_JAVA_11_UTILITIES)
+				.filter(utility -> !"jaotc".equals(utility))
+				.toArray(String[]::new);
 
-        // Convert the list back to an array
-        String[] updatedIBMJDK11Utilities = filteredIBMJDK11Utilities.toArray(new String[0]);
-
-        LOGGER.info("DockerImageTest:javaUtilitiesTest::Running check for JDK11 on ppc64le or s390x.");
-        Assertions.assertThat(content.listDirContent("$JAVA_HOME/bin")).contains(updatedIBMJDK11Utilities);
+				LOGGER.info("DockerImageTest:javaUtilitiesTest::Running check for JDK11 on ppc64le or s390x.");
+				Assertions.assertThat(content.listDirContent("$JAVA_HOME/bin")).contains(updatedIBMJDK11Utilities);
 			}
 			else {
 				LOGGER.info("DockerImageTest:javaUtilitiesTest::Running check for jdk11.");


### PR DESCRIPTION
The JDK 11 app "jaotc" is not part of the IBM ppc64le or s390x package. Also, removed old OpenJ9 references as it is not longer used.