### PR TITLE
Update Label Usage tests to reflect the updates in the container images.

### DIFF
--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
@@ -127,13 +127,13 @@ public class DockerImageTest extends AbstractDockerImageTest {
 		if (OpenJDKTestConfig.isRHEL7()){
 			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/");
 		} else if( OpenJDKTestConfig.isOpenJDK8() ) {
-			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://jboss-container-images.github.io/openjdk/");
+			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://rh-openjdk.github.io/redhat-openjdk-containers/");
 		} else if (OpenJDKTestConfig.isOpenJDK11()){
-			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://jboss-container-images.github.io/openjdk/");
+			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://rh-openjdk.github.io/redhat-openjdk-containers/");
 		} else if (OpenJDKTestConfig.isOpenJDK17()){
-			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://jboss-container-images.github.io/openjdk/");
+			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://rh-openjdk.github.io/redhat-openjdk-containers/");
 		} else if (OpenJDKTestConfig.isOpenJDK21()){
-			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://jboss-container-images.github.io/openjdk/");
+			Assertions.assertThat(metadata.labels().get("usage")).isEqualTo("https://rh-openjdk.github.io/redhat-openjdk-containers/");
 		}
 
 	}


### PR DESCRIPTION
[OPENJDK-3409][OPENJDK-3390] Update Labels Usage tests for jdk 8, 11, 17, 21 to support the metadata change.