### PR TITLE
[OPENJDK-3339]Update check for Rhel 8 images to support els and ubi images.

### DIFF
--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/OpenJDKTestConfig.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/OpenJDKTestConfig.java
@@ -69,7 +69,7 @@ public class OpenJDKTestConfig {
 	}
 
 	public static boolean isRHEL8() {
-		return getImageUrl().contains("ubi8");
+		return checkImageOsVersion("8");
 	}
 
 	public static boolean isRHEL9() {


### PR DESCRIPTION
This is the Rhel 8 update similar to the Rhel 9 as seen here:  https://github.com/rh-openjdk/jdkContainerOcpTests/pull/10