### PR TITLE
jdk11-els: Update to Maven 3.9 in RHEL-9

### DIFF
--- a/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
+++ b/test-openjdk/src/test/java/com/redhat/qe/openjdk/image/DockerImageTest.java
@@ -253,11 +253,7 @@ public class DockerImageTest extends AbstractDockerImageTest {
 		} else if (OpenJDKTestConfig.isRHEL8()) {
 			result.put("MAVEN_VERSION", "3.8");
 		} else {
-			if (OpenJDKTestConfig.isOpenJDK11()) {
-				result.put("MAVEN_VERSION", "3.8");
-			} else {
-				result.put("MAVEN_VERSION", "3.9");
-			}
+			result.put("MAVEN_VERSION", "3.9");
 		}
 
 


### PR DESCRIPTION
But keep Maven 3.8 in RHEL-8